### PR TITLE
Add test deploy text to InitialMenu scene

### DIFF
--- a/src/game/scenes/InitialMenu.js
+++ b/src/game/scenes/InitialMenu.js
@@ -110,6 +110,9 @@ export default class InitialMenu extends Phaser.Scene {
         color: "#ffffff",
       }
     );
+    this.testDeploy = this.add.text(width * 0.5, height * 0.6, "Test Deploy", {
+      color: "#ffffff",
+    });
   }
 
   update() {


### PR DESCRIPTION
This pull request introduces a small UI update to the `InitialMenu` scene by adding a new "Test Deploy" text element to the menu.

* Added a "Test Deploy" text label to the `InitialMenu` scene UI, positioned at the center of the screen. (`src/game/scenes/InitialMenu.js`)